### PR TITLE
Switch from x-magento-init to a simple require

### DIFF
--- a/src/view/base/templates/page/js/magewire-config.phtml
+++ b/src/view/base/templates/page/js/magewire-config.phtml
@@ -14,13 +14,12 @@ use Magewirephp\Magewire\ViewModel\Magewire;
 
 $magewireScripts = $block->getData('viewModel');
 ?>
-<script type="text/x-magento-init">
-{
-    "*": {
-        "Magewirephp_MagewireRequireJs/js/magewire": {
+<script>
+    require(['Magewirephp_MagewireRequireJs/js/magewire'], function (magewire) {
+        magewire({
             "app_url": "<?= $escaper->escapeUrl($magewireScripts->getApplicationUrl()) ?>",
             "app_debug": <?= $escaper->escapeJs($magewireScripts->isDeveloperMode() ? 'true' : 'false') ?>
-        }
-    }
-}
+        });
+    });
 </script>
+


### PR DESCRIPTION
By using x-magento-init, one will need to wait until the Magento UIComponent logic has scanned for these HTML attributes. By turning this into a simple inline require(), the speed does up.